### PR TITLE
Add option to inherit groups

### DIFF
--- a/group_set.go
+++ b/group_set.go
@@ -1,0 +1,28 @@
+package sheriff
+
+type groupSet map[string]int
+
+func (s groupSet) incrementGroups(groups []string) {
+	for i := range groups {
+		s[groups[i]]++
+	}
+}
+
+func (s groupSet) decrementGroups(groups []string) {
+	for i := range groups {
+		s[groups[i]]--
+	}
+}
+
+func (s groupSet) contains(group string) bool {
+	return s[group] > 0
+}
+
+func (s groupSet) containsAny(groups []string) bool {
+	for i := range groups {
+		if s.contains(groups[i]) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This adds an Option.InheritGroups, which, when combined with Options.OutputFieldsWithNoGroup, allows you to specify a small set of fields that could be used as additional output.

It goes through great lengths to maintain compatibility with the embedded struct behavior.

It also updates the tests to use `assert.JSONEq`, to avoid false positives from the output being reordered.